### PR TITLE
Step2 - 조회 성능 개선하기

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src\\main\\resources\\config"]
+	path = src\\main\\resources\\config
+	url = https://github.com/wrallee/infra-subway-config.git

--- a/README.md
+++ b/README.md
@@ -138,4 +138,5 @@ npm run dev
 
 
 2. 페이징 쿼리를 적용한 API endpoint를 알려주세요
-
+   - Endpoint: https://우찬.웹.한국/favorites?page=0&size=5
+   - Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ3b290ZWNhbUBwcm8uMm5kIiwiaWF0IjoxNjI1OTIwNjg3LCJleHAiOjE2MjU5MjQyODd9.N4HcEJZ-GVYHcK7GgLzjQEiLFHajgb7Zih3wBUu0oVQ

--- a/README.md
+++ b/README.md
@@ -59,6 +59,83 @@ npm run dev
 
 ### 2단계 - 조회 성능 개선하기
 1. 인덱스 적용해보기 실습을 진행해본 과정을 공유해주세요
+   - [x] 주어진 데이터셋을 활용하여 아래 조회 결과를 100ms 이하로 반환
+      - [x] Coding as a Hobby 와 같은 결과를 반환하세요.
+         ```sql
+         SELECT hobby,
+         round(count(hobby) / (SELECT count(hobby) FROM programmer) * 100, 1) AS "Coding as a Hobby"
+         FROM programmer
+         GROUP BY hobby
+        
+         # 결과: 0.297s -> 0.047s
+         ```
+         - `programmer.hobby` 컬럼에 인덱스를 줘서 정렬시켰습니다.
+         - 조회 시 `programmer.hobby` 컬럼을 명시하여 커버링 인덱스를 적용했습니다. 
+         - count 함수에 `id`, `*`로도 각각 지정해 봤는데 `*`로 지정 시 옵티마이저가 자동으로 커버링 인덱스를 적용했습니다.
+
+      - [x] 프로그래머별로 해당하는 병원 이름을 반환하세요. (covid.id, hospital.name)
+         ```sql
+         SELECT c.id, h.name
+         FROM covid c, hospital h
+         WHERE c.hospital_id = h.id
+           AND c.id >= 1000
+         LIMIT 0, 1000
+         
+         # 결과: 0.735s -> 0.000s
+         ```
+         - `hospital.id` 컬럼을 PK로 지정했습니다.
+         - `covid.id` 컬럼을 PK로 지정하고, 페이징 쿼리와 `covid.id >= 1000`를 적용해서 `Index Range Scan`이 동작하도록 수정했습니다.
+
+      - [x] 프로그래밍이 취미인 학생 혹은 주니어(0-2년)들이 다닌 병원 이름을 반환하고 user.id 기준으로 정렬하세요. (covid.id, hospital.name, user.Hobby, user.DevType, user.YearsCoding)
+         ```sql
+         SELECT p.id, h.name
+         FROM programmer p, covid c, hospital h
+         WHERE p.id = c.id
+           AND c.hospital_id = h.id
+           AND (p.hobby = 'Yes' OR p.years_coding = '0-2 years')
+           AND p.id >= 1000
+         LIMIT 0, 1000
+         
+         # 결과: 0.360 -> 0.000s
+         ```
+         - `programmer.id` 컬럼을 PK로 지정했습니다.
+         - `programmer.id` 컬럼을 PK로 지정하고, 페이징 쿼리와 `programmer.id >= 1000`를 적용해서 `Index Range Scan`이 동작하도록 수정했습니다.
+
+      - [x] 서울대병원에 다닌 20대 India 환자들을 병원에 머문 기간별로 집계하세요. (covid.Stay)
+         ```sql
+         SELECT m.id, c.stay, h.name
+         FROM member m, programmer p, covid c, hospital h
+         WHERE m.id = p.id
+           AND p.id = c.id
+           AND c.hospital_id = h.id
+           AND m.age BETWEEN 20 AND 29
+           AND h.name = '서울대병원'
+           AND p.country = 'India'
+         ORDER BY c.stay
+         
+            # 결과: 0.172s -> 0.032s
+         ```
+         - `member.age`, `programmer.country`, `hospital.name` 컬럼에 인덱스를 적용했습니다.
+        
+      - [x] 서울대병원에 다닌 30대 환자들을 운동 횟수별로 집계하세요. (user.Exercise)
+         ```sql
+         SELECT p.exercise, count(p.id)
+         FROM hospital h, covid c, member m, programmer p
+         WHERE h.id = c.hospital_id
+           AND c.id = m.id
+           AND c.id = p.id
+           AND h.name = '서울대병원'
+           AND m.age BETWEEN 30 AND 39
+         GROUP BY p.exercise
+         ORDER BY null
+         
+         # 결과: 0.203s -> 0.016s
+         ```
+         - `covid.hospital_id` 컬럼에 인덱스를 적용하여 성능이 향상됐습니다. 아래 순서로 스캔이 진행됐습니다.
+            1. `hospital.name` 인덱스 스캔(Non-Unique Key Lookup)
+            2. `hospital.id = covid.hospital_id` 인덱스 스캔(Non-Unique Key Lookup)
+            3. `covid.id = member.id`, `covid.id = programmer.id` PK 스캔(Unique Key Lookup)
+
 
 2. 페이징 쿼리를 적용한 API endpoint를 알려주세요
 

--- a/README.md
+++ b/README.md
@@ -138,5 +138,5 @@ npm run dev
 
 
 2. 페이징 쿼리를 적용한 API endpoint를 알려주세요
-   - Endpoint: https://우찬.웹.한국/favorites?page=0&size=5
-   - Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ3b290ZWNhbUBwcm8uMm5kIiwiaWF0IjoxNjI1OTIwNjg3LCJleHAiOjE2MjU5MjQyODd9.N4HcEJZ-GVYHcK7GgLzjQEiLFHajgb7Zih3wBUu0oVQ
+   - Endpoint: https://우찬.웹.한국/favorites?page=1&size=5
+   - Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ3b290ZWNhbUBwcm8uMm5kIiwiaWF0IjoxNjI1OTc4OTk2LCJleHAiOjE2MjU5ODI1OTZ9.HNT46B7kI-690kM1WRAi7344hG02h-u-Y3j3jjsjkY0

--- a/src/main/java/nextstep/subway/SubwayApplication.java
+++ b/src/main/java/nextstep/subway/SubwayApplication.java
@@ -2,11 +2,7 @@ package nextstep.subway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-@EnableJpaRepositories
-@EnableJpaAuditing
 @SpringBootApplication
 public class SubwayApplication {
 

--- a/src/main/java/nextstep/subway/SubwayApplication.java
+++ b/src/main/java/nextstep/subway/SubwayApplication.java
@@ -2,7 +2,11 @@ package nextstep.subway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
+@EnableJpaAuditing
+@EnableJpaRepositories(basePackages = {"nextstep.subway"})
 @SpringBootApplication
 public class SubwayApplication {
 

--- a/src/main/java/nextstep/subway/common/CacheConfig.java
+++ b/src/main/java/nextstep/subway/common/CacheConfig.java
@@ -1,5 +1,7 @@
 package nextstep.subway.common;
 
+import java.time.Duration;
+
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CachingConfigurerSupport;
 import org.springframework.cache.annotation.EnableCaching;
@@ -20,6 +22,7 @@ public class CacheConfig extends CachingConfigurerSupport {
     @Bean
     public CacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofDays(14L))
             .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
             .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
 

--- a/src/main/java/nextstep/subway/common/DataBaseConfig.java
+++ b/src/main/java/nextstep/subway/common/DataBaseConfig.java
@@ -1,0 +1,63 @@
+package nextstep.subway.common;
+
+import static nextstep.subway.common.ReplicationRoutingDataSource.*;
+
+import java.util.HashMap;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+@Configuration
+@EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class})
+@EnableTransactionManagement
+@EnableJpaRepositories(basePackages = {"nextstep.subway"})
+@EnableJpaAuditing
+class DataBaseConfig {
+
+    @Bean
+    @ConfigurationProperties(prefix = "spring.datasource.hikari.master")
+    public DataSource masterDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @Bean
+    @ConfigurationProperties(prefix = "spring.datasource.hikari.slave")
+    public DataSource slaveDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @Bean
+    public DataSource routingDataSource(@Qualifier("masterDataSource") DataSource master,
+        @Qualifier("slaveDataSource") DataSource slave) {
+        ReplicationRoutingDataSource routingDataSource = new ReplicationRoutingDataSource();
+
+        HashMap<Object, Object> sources = new HashMap<>();
+        sources.put(DATASOURCE_KEY_MASTER, master);
+        sources.put(DATASOURCE_KEY_SLAVE, slave);
+
+        routingDataSource.setTargetDataSources(sources);
+        routingDataSource.setDefaultTargetDataSource(master);
+
+        return routingDataSource;
+    }
+
+    @Primary
+    @Bean
+    public DataSource dataSource(@Qualifier("routingDataSource") DataSource routingDataSource) {
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+}

--- a/src/main/java/nextstep/subway/common/DataBaseConfig.java
+++ b/src/main/java/nextstep/subway/common/DataBaseConfig.java
@@ -14,8 +14,7 @@ import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
@@ -24,8 +23,7 @@ import com.zaxxer.hikari.HikariDataSource;
 @Configuration
 @EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class})
 @EnableTransactionManagement
-@EnableJpaRepositories(basePackages = {"nextstep.subway"})
-@EnableJpaAuditing
+@Profile("prod | local")
 class DataBaseConfig {
 
     @Bean

--- a/src/main/java/nextstep/subway/common/ReplicationRoutingDataSource.java
+++ b/src/main/java/nextstep/subway/common/ReplicationRoutingDataSource.java
@@ -1,0 +1,17 @@
+package nextstep.subway.common;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class ReplicationRoutingDataSource extends AbstractRoutingDataSource {
+    public static final String DATASOURCE_KEY_MASTER = "master";
+    public static final String DATASOURCE_KEY_SLAVE = "slave";
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        boolean isReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+        return (isReadOnly)
+            ? DATASOURCE_KEY_SLAVE
+            : DATASOURCE_KEY_MASTER;
+    }
+}

--- a/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
+++ b/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
@@ -9,6 +9,8 @@ import nextstep.subway.favorite.dto.FavoriteResponse;
 import nextstep.subway.station.domain.Station;
 import nextstep.subway.station.domain.StationRepository;
 import nextstep.subway.station.dto.StationResponse;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.HashSet;
@@ -33,8 +35,8 @@ public class FavoriteService {
         favoriteRepository.save(favorite);
     }
 
-    public List<FavoriteResponse> findFavorites(LoginMember loginMember) {
-        List<Favorite> favorites = favoriteRepository.findByMemberId(loginMember.getId());
+    public List<FavoriteResponse> findFavorites(LoginMember loginMember, Pageable pageable) {
+        List<Favorite> favorites = favoriteRepository.findByMemberId(loginMember.getId(), pageable);
         Map<Long, Station> stations = extractStations(favorites);
 
         return favorites.stream()

--- a/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
+++ b/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
@@ -1,9 +1,10 @@
 package nextstep.subway.favorite.domain;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
-    List<Favorite> findByMemberId(Long memberId);
+    List<Favorite> findByMemberId(Long memberId, Pageable pageable);
 }

--- a/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
@@ -5,6 +5,8 @@ import nextstep.subway.auth.domain.LoginMember;
 import nextstep.subway.favorite.application.FavoriteService;
 import nextstep.subway.favorite.dto.FavoriteRequest;
 import nextstep.subway.favorite.dto.FavoriteResponse;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,8 +30,9 @@ public class FavoriteController {
     }
 
     @GetMapping("/favorites")
-    public ResponseEntity<List<FavoriteResponse>> getFavorites(@AuthenticationPrincipal LoginMember loginMember) {
-        List<FavoriteResponse> favorites = favoriteService.findFavorites(loginMember);
+    public ResponseEntity<List<FavoriteResponse>> getFavorites(
+            @AuthenticationPrincipal LoginMember loginMember, Pageable pageable) {
+        List<FavoriteResponse> favorites = favoriteService.findFavorites(loginMember, pageable);
         return ResponseEntity.ok().body(favorites);
     }
 

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -39,22 +39,22 @@ public class LineService {
         return LineResponse.of(persistLine);
     }
 
+    @Cacheable(value = "lines", key = FIND_LINES)
     public List<LineResponse> findLineResponses() {
         return findLines().stream()
                 .map(LineResponse::of)
                 .collect(Collectors.toList());
     }
 
-    @Cacheable(value = "lines", key = FIND_LINES)
     public List<Line> findLines() {
         return lineRepository.findAll();
     }
 
-    @Cacheable(value = "line", key = "#id")
     public Line findLineById(Long id) {
         return lineRepository.findById(id).orElseThrow(RuntimeException::new);
     }
 
+    @Cacheable(value = "line", key = "#id")
     public LineResponse findLineResponseById(Long id) {
         Line persistLine = findLineById(id);
         return LineResponse.of(persistLine);

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -20,6 +20,9 @@ import java.util.stream.Collectors;
 @Service
 @Transactional
 public class LineService {
+
+    private static final String FIND_LINES = "'findLines'";
+
     private LineRepository lineRepository;
     private StationService stationService;
 
@@ -28,10 +31,7 @@ public class LineService {
         this.stationService = stationService;
     }
 
-    @Caching(evict = {
-        @CacheEvict(value = "path", allEntries = true),
-        @CacheEvict(value = "lines", allEntries = true)
-    })
+    @CacheEvict(value = "lines", key = FIND_LINES)
     public LineResponse saveLine(LineRequest request) {
         Station upStation = stationService.findById(request.getUpStationId());
         Station downStation = stationService.findById(request.getDownStationId());
@@ -39,22 +39,21 @@ public class LineService {
         return LineResponse.of(persistLine);
     }
 
-    @Cacheable(value = "lines")
     public List<LineResponse> findLineResponses() {
-        List<Line> persistLines = lineRepository.findAll();
-        return persistLines.stream()
+        return findLines().stream()
                 .map(LineResponse::of)
                 .collect(Collectors.toList());
     }
 
+    @Cacheable(value = "lines", key = FIND_LINES)
     public List<Line> findLines() {
         return lineRepository.findAll();
     }
 
+    @Cacheable(value = "line", key = "#id")
     public Line findLineById(Long id) {
         return lineRepository.findById(id).orElseThrow(RuntimeException::new);
     }
-
 
     public LineResponse findLineResponseById(Long id) {
         Line persistLine = findLineById(id);
@@ -62,25 +61,25 @@ public class LineService {
     }
 
     @Caching(evict = {
-        @CacheEvict(value = "path", allEntries = true),
-        @CacheEvict(value = "lines", allEntries = true)
+        @CacheEvict(value = "line", key = "#id"),
+        @CacheEvict(value = "lines", key = FIND_LINES)
     })
     public void updateLine(Long id, LineRequest lineUpdateRequest) {
-        Line persistLine = lineRepository.findById(id).orElseThrow(RuntimeException::new);
+        Line persistLine = findLineById(id);
         persistLine.update(new Line(lineUpdateRequest.getName(), lineUpdateRequest.getColor()));
     }
 
     @Caching(evict = {
-        @CacheEvict(value = "path", allEntries = true),
-        @CacheEvict(value = "lines", allEntries = true)
+        @CacheEvict(value = "line", key = "#id"),
+        @CacheEvict(value = "lines", key = FIND_LINES)
     })
     public void deleteLineById(Long id) {
         lineRepository.deleteById(id);
     }
 
     @Caching(evict = {
-        @CacheEvict(value = "path", allEntries = true),
-        @CacheEvict(value = "lines", allEntries = true)
+        @CacheEvict(value = "line", key = "#lineId"),
+        @CacheEvict(value = "lines", key = FIND_LINES)
     })
     public void addLineStation(Long lineId, SectionRequest request) {
         Line line = findLineById(lineId);
@@ -90,8 +89,8 @@ public class LineService {
     }
 
     @Caching(evict = {
-        @CacheEvict(value = "path", allEntries = true),
-        @CacheEvict(value = "lines", allEntries = true)
+        @CacheEvict(value = "line", key = "#lineId"),
+        @CacheEvict(value = "lines", key = FIND_LINES)
     })
     public void removeLineStation(Long lineId, Long stationId) {
         Line line = findLineById(lineId);

--- a/src/main/java/nextstep/subway/station/application/StationService.java
+++ b/src/main/java/nextstep/subway/station/application/StationService.java
@@ -16,19 +16,22 @@ import java.util.stream.Collectors;
 @Service
 @Transactional
 public class StationService {
+
+    private static final String FIND_STATIONS = "'findAllStations'";
+
     private StationRepository stationRepository;
 
     public StationService(StationRepository stationRepository) {
         this.stationRepository = stationRepository;
     }
 
-    @CacheEvict(value = "stations", allEntries = true)
+    @CacheEvict(value = "stations", key = FIND_STATIONS)
     public StationResponse saveStation(StationRequest stationRequest) {
         Station persistStation = stationRepository.save(stationRequest.toStation());
         return StationResponse.of(persistStation);
     }
 
-    @Cacheable(value = "stations")
+    @Cacheable(value = "stations", key = FIND_STATIONS)
     @Transactional(readOnly = true)
     public List<StationResponse> findAllStations() {
         List<Station> stations = stationRepository.findAll();
@@ -38,7 +41,7 @@ public class StationService {
                 .collect(Collectors.toList());
     }
 
-    @CacheEvict(value = "stations", allEntries = true)
+    @CacheEvict(value = "stations", key = FIND_STATIONS)
     public void deleteStationById(Long id) {
         stationRepository.deleteById(id);
     }


### PR DESCRIPTION
안녕하세요
안정적인 서비스 만들기 2단계 마지막 미션 제출합니다!

1단계에서 피드백 주신 내용을 적용해봤는데요
엔티티를 캐시하는 부분이 `Serialize`와 `양방향 연관관계` 때문에 좀처럼 잘 안되었습니다.. 😭
`@CacheEvit(allEntries = true)`로 인한 병목 리스크는 부분은 해당 어노테이션을 제거하고, 최초 캐시 설정 시 유효기간을 두는쪽으로 해봤는데 괜찮을지 모르겠네요.

2단계 미션에서는 해설에 있는 쿼리와 실행계획이 제 데이터베이스에서 돌아가는 쿼리와 어떻게 다른지 비교해보면서 진행했습니다. 인덱스를 주는 것에 따라 실행계획이 변경되고 성능이 개선되는걸 보면서 재밌게 진행한 것 같습니다. 😊

리뷰 부탁드리겠습니다.

---

~~데이터베이스 master, slave 구성을 안했었네요. 😱~~
~~구성하고 다시 요청드리겠습니다!~~
👉 적용했습니다!